### PR TITLE
Added the texture class and made it so now the frame buffer is using it.

### DIFF
--- a/3D_Object_Viewer.vcxproj
+++ b/3D_Object_Viewer.vcxproj
@@ -104,7 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);GLEW_STATIC</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)Dependencies\glfw\glfw\include;$(SolutionDir)Dependencies\glew\glew-2.2.0\include;$(SolutionDIr)Dependencies\glm\glm;$(SolutionDir)Dependencies\imgui\imgui;$(SolutionDir)Dependencies\imgui\imgui\backends;$(SolutionDir)src;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src\include;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src;$(SolutionDir)Dependencies\assimp\assimp\include;$(SolutionDir)Shaders;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Dependencies\glfw\glfw\include;$(SolutionDir)Dependencies\glew\glew-2.2.0\include;$(SolutionDIr)Dependencies\glm\glm;$(SolutionDir)Dependencies\imgui\imgui;$(SolutionDir)Dependencies\imgui\imgui\backends;$(SolutionDir)src;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src\include;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src;$(SolutionDir)Dependencies\assimp\assimp\include;$(SolutionDir)Shaders;$(SolutionDir)Dependencies\stbi_image;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -125,7 +125,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);GLEW_STATIC</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)Dependencies\glfw\glfw\include;$(SolutionDir)Dependencies\glew\glew-2.2.0\include;$(SolutionDIr)Dependencies\glm\glm;$(SolutionDir)Dependencies\imgui\imgui;$(SolutionDir)Dependencies\imgui\imgui\backends;$(SolutionDir)src;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src\include;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src;$(SolutionDir)Dependencies\assimp\assimp\include;$(SolutionDir)Shaders;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Dependencies\glfw\glfw\include;$(SolutionDir)Dependencies\glew\glew-2.2.0\include;$(SolutionDIr)Dependencies\glm\glm;$(SolutionDir)Dependencies\imgui\imgui;$(SolutionDir)Dependencies\imgui\imgui\backends;$(SolutionDir)src;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src\include;$(SolutionDir)Dependencies\nativefiledialog\nativefiledialog\src;$(SolutionDir)Dependencies\assimp\assimp\include;$(SolutionDir)Shaders;$(SolutionDir)Dependencies\stbi_image;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -160,6 +160,7 @@
     <ClCompile Include="src\VertexAttributeObject.cpp" />
     <ClCompile Include="src\WindowInputFuncs.cpp" />
     <ClCompile Include="src\WindowHandler.cpp" />
+    <ClCompile Include="src\Texture.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Dependencies\glew\glew-2.2.0\build\vc15\glew_static.vcxproj">
@@ -196,6 +197,7 @@
     <ClInclude Include="src\VertexAttributeObject.h" />
     <ClInclude Include="src\WindowInputFuncs.h" />
     <ClInclude Include="src\WindowHandler.h" />
+    <ClInclude Include="src\Texture.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\ColorShader.glsl" />

--- a/3D_Object_Viewer.vcxproj.filters
+++ b/3D_Object_Viewer.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="src\InputHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Texture.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Dependencies\imgui\imgui\imconfig.h">
@@ -141,6 +144,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\InputHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Texture.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/imgui.ini
+++ b/imgui.ini
@@ -4,13 +4,13 @@ Size=300,1500
 Collapsed=0
 
 [Window][Test]
-Pos=1637,8
-Size=275,859
+Pos=1597,8
+Size=315,841
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Loading panel]
-Pos=8,869
+Pos=8,851
 Size=1904,132
 Collapsed=0
 DockId=0x00000006,0
@@ -42,7 +42,7 @@ Collapsed=0
 
 [Window][Model data.]
 Pos=8,8
-Size=206,859
+Size=206,841
 Collapsed=0
 DockId=0x00000003,0
 
@@ -57,21 +57,21 @@ Collapsed=0
 
 [Window][DockSpace Demo]
 Pos=0,0
-Size=1920,1009
+Size=1920,991
 Collapsed=0
 
 [Window][Scene]
 Pos=216,8
-Size=1419,859
+Size=1379,841
 Collapsed=0
 DockId=0x00000001,0
 
 [Docking][Data]
-DockSpace       ID=0x3BC79352 Window=0x4647B76E Pos=8,8 Size=1904,993 Split=Y
+DockSpace       ID=0x3BC79352 Window=0x4647B76E Pos=8,8 Size=1904,975 Split=Y
   DockNode      ID=0x00000005 Parent=0x3BC79352 SizeRef=1904,859 Split=X
     DockNode    ID=0x00000003 Parent=0x00000005 SizeRef=206,993 HiddenTabBar=1 Selected=0x40758CDD
     DockNode    ID=0x00000004 Parent=0x00000005 SizeRef=1696,993 Split=X
-      DockNode  ID=0x00000001 Parent=0x00000004 SizeRef=1417,984 CentralNode=1 HiddenTabBar=1 Selected=0xE192E354
-      DockNode  ID=0x00000002 Parent=0x00000004 SizeRef=275,984 HiddenTabBar=1 Selected=0x44A6A033
+      DockNode  ID=0x00000001 Parent=0x00000004 SizeRef=1379,984 CentralNode=1 HiddenTabBar=1 Selected=0xE192E354
+      DockNode  ID=0x00000002 Parent=0x00000004 SizeRef=315,984 HiddenTabBar=1 Selected=0x44A6A033
   DockNode      ID=0x00000006 Parent=0x3BC79352 SizeRef=1904,132 Selected=0x3D0BEFFE
 

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -5,13 +5,13 @@ OBJ_Viewer::Framebuffer::Framebuffer(int width, int height, FramebufferAttachmen
 	glGenFramebuffers(1, &this->m_framebuffer);
 	glBindFramebuffer(GL_FRAMEBUFFER, this->m_framebuffer);
 
-	glGenTextures(1, &this->m_framebufferTextureID);
-	glBindTexture(GL_TEXTURE_2D, this->m_framebufferTextureID);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	TextureBuilder builder;
+	this->m_texture = 
+		builder.SetTextureFormat(TEXTURE_FORMAT_RGB).
+		SetTextureInternalFormat(TEXTURE_INTERNAL_FORMAT_RGB).
+		SetTextureSize({ width,height }).buildTexture();
 
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, this->m_framebufferTextureID, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,this->m_texture->GetTextureHandle(), 0);
 	glGenRenderbuffers(1, &this->m_readBuffer);
 	glBindRenderbuffer(GL_RENDERBUFFER, this->m_readBuffer);
 	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
@@ -28,7 +28,7 @@ OBJ_Viewer::Framebuffer::Framebuffer(int width, int height, FramebufferAttachmen
 bool OBJ_Viewer::Framebuffer::isFramebufferValid() const
 {
 	BindFramebuffer();
-	const bool result = glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE;;
+	const bool result = glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE;
 	UnbindFramebuffer();
 	return result;
 }
@@ -36,13 +36,8 @@ bool OBJ_Viewer::Framebuffer::isFramebufferValid() const
 void OBJ_Viewer::Framebuffer::ResizeFramebuffer(int newWidth, int newHeight)
 {
 	BindFramebuffer();
-
-	glBindTexture(GL_TEXTURE_2D, this->m_framebufferTextureID);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, newWidth, newHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, this->m_framebufferTextureID, 0);
-
+	this->m_texture->ResizeTexture({ newWidth,newHeight });
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, this->m_texture->GetTextureHandle(), 0);
 	glBindRenderbuffer(GL_RENDERBUFFER, this->m_readBuffer);
 	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, newWidth, newHeight);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->m_readBuffer);
@@ -52,7 +47,6 @@ void OBJ_Viewer::Framebuffer::ResizeFramebuffer(int newWidth, int newHeight)
 
 OBJ_Viewer::Framebuffer::~Framebuffer()
 {
-	glDeleteTextures(1, &this->m_framebufferTextureID);
 	glDeleteFramebuffers(1, &this->m_framebuffer);
 	glDeleteRenderbuffers(1, &this->m_readBuffer);
 }

--- a/src/Framebuffer.h
+++ b/src/Framebuffer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include<GL/glew.h>
+#include"Texture.h"
 namespace OBJ_Viewer {
 
 	enum FramebufferAttachmentsFlags
@@ -16,7 +17,7 @@ namespace OBJ_Viewer {
 		//FramebufferAttachmentsFlags currently not used
 		Framebuffer(int width, int height, FramebufferAttachmentsFlags attachmentFlags);
 		GLuint GetFramebufferHandle()const { return this->m_framebuffer; }
-		GLuint GetFramebufferTextureHandle()const { return this->m_framebufferTextureID; }
+		std::shared_ptr<Texture> GetFramebufferTexture()const { return this->m_texture; }
 		void BindFramebuffer()const { glBindFramebuffer(GL_FRAMEBUFFER, this->m_framebuffer); }
 		void UnbindFramebuffer()const { glBindFramebuffer(GL_FRAMEBUFFER, 0); }
 		bool isFramebufferValid()const;
@@ -25,7 +26,7 @@ namespace OBJ_Viewer {
 	private:
 		GLuint m_framebuffer;
 		GLuint m_readBuffer;
-		GLuint m_framebufferTextureID;
+		std::shared_ptr<Texture> m_texture;
 	};
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -48,7 +48,6 @@ void OBJ_Viewer::RenderingCoordinator::RenderScene()
 	glClearColor(0, 0, 0, 1);
 	m_mainRenderer.RenderObject(m_rendererShaders.colorShader, *m_currentlyLoadedModel, *m_Camera);
 	this->m_sceneFramebuffer.UnbindFramebuffer();
-
 }
 
 OBJ_Viewer::RenderingCoordinator::RenderingCoordinator(Window* windowHandler, InputHandler* pInputHandler):m_currentlyLoadedModel(GenerateCubeModel()),
@@ -65,7 +64,7 @@ OBJ_Viewer::RenderingCoordinator::RenderingCoordinator(Window* windowHandler, In
 
 void OBJ_Viewer::RenderingCoordinator::RenderImGui()
 {
-	m_imGuiUIRenderer.RenderUI(this->m_sceneFramebuffer.GetFramebufferTextureHandle());
+	m_imGuiUIRenderer.RenderUI(this->m_sceneFramebuffer.GetFramebufferTexture()->GetTextureHandle());
 }
 
 void OBJ_Viewer::Renderer::RenderObject(const ShaderClass& shaderToUse, const Model& modelToRender, const Camera& mainCamera)

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,0 +1,69 @@
+#include "Texture.h"
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+#include<iostream>
+OBJ_Viewer::Texture::Texture(const unsigned char* data, TextureInternalFormat textureInternalFormat, TextureFormat textureFormat,
+	TextureSize textureSize, TexturePixelDataType dataType, TextureWrap textureWrapS, TextureWrap textureWrapT)
+	:m_textureSize(textureSize),m_textureWrapS(textureWrapS), m_textureWrapT(textureWrapT),
+	m_textureFormat(textureFormat), m_textureInternalFormat(textureInternalFormat),
+	m_texturePixelDataType(dataType)
+{
+	glGenTextures(1, &this->m_textureHandle);
+	SetTextureProperties(data);
+}
+
+OBJ_Viewer::Texture::~Texture()
+{
+	glDeleteTextures(1, &this->m_textureHandle);
+}
+
+void OBJ_Viewer::Texture::BindTexture() const
+{
+	glBindTexture(1, this->m_textureHandle);
+}
+
+void OBJ_Viewer::Texture::ResizeTexture(TextureSize newSize)
+{
+	this->m_textureSize = newSize;
+	SetTextureProperties(nullptr);
+}
+
+std::shared_ptr<unsigned char[]> OBJ_Viewer::Texture::GetPixelData()
+{
+	//Should be based on the type of pixel data;
+	const int ArrSize = this->m_textureSize.height * this->m_textureSize.height * sizeof(unsigned char);
+	std::shared_ptr<unsigned char[]> my_array(new unsigned char[ArrSize]);
+	glGetTexImage(GL_TEXTURE_2D, 0, this->m_textureFormat, this->m_texturePixelDataType, my_array.get());
+	return my_array;
+}
+
+void OBJ_Viewer::Texture::SetTextureProperties(const unsigned char* data)
+{
+	glBindTexture(GL_TEXTURE_2D, this->m_textureHandle);
+
+	glTexImage2D(GL_TEXTURE_2D, 0, m_textureInternalFormat,
+		m_textureSize.width, m_textureSize.height, 0, m_textureFormat,m_texturePixelDataType,data);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_textureWrapS);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, m_textureWrapT);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+OBJ_Viewer::TexturePixelDataWrapper::TexturePixelDataWrapper(const char* path, TextureSize* pTextureSize, int* pPresentChannelsCount)
+{
+	stbi_set_flip_vertically_on_load(true);
+	m_pixelData = stbi_load(path, &pTextureSize->width, &pTextureSize->height, pPresentChannelsCount, 0);
+	if (!m_pixelData)
+	{	
+		std::cout << "[ERROR]:STBI_IMAGE failed to read or allocate texture at path." << path << '\n';
+	}
+}
+
+OBJ_Viewer::TexturePixelDataWrapper::~TexturePixelDataWrapper()
+{
+	if (m_pixelData)
+		stbi_image_free(m_pixelData);
+}

--- a/src/Texture.h
+++ b/src/Texture.h
@@ -1,0 +1,113 @@
+#pragma once
+#include<GL/glew.h>
+#include<memory>
+namespace OBJ_Viewer {
+#pragma region TextureStructs
+	enum TextureFormat
+	{
+		TEXTURE_FORMAT_R = GL_RED,
+		TEXTURE_FORMAT_RG = GL_RG,
+		TEXTURE_FORMAT_RGB = GL_RGB,
+		TEXTURE_FORMAT_RGBA = GL_RGBA
+	};
+	enum TextureInternalFormat {
+		TEXTURE_INTERNAL_FORMAT_DEPTH = GL_DEPTH_COMPONENT,
+		TEXTURE_INTERNAL_FORMAT_DEPTH_STENCIL = GL_DEPTH_STENCIL,
+		TEXTURE_INTERNAL_FORMAT_R = GL_RED,
+		TEXTURE_INTERNAL_FORMAT_RG = GL_RG,
+		TEXTURE_INTERNAL_FORMAT_RGB = GL_RGB,
+		TEXTURE_INTERNAL_FORMAT_RGBA = GL_RGBA,
+	};
+	enum TextureFilter
+	{
+		TEXTURE_FILTER_LINEAR = GL_LINEAR,
+		TEXTURE_FILTER_NEAREST = GL_NEAREST
+	};
+	enum TextureWrap
+	{
+		TEXTURE_WRAP_REPEAT = GL_REPEAT,
+		TEXTURE_WRAP_MIRRORED_REPEAT = GL_MIRRORED_REPEAT
+		//TODO:Add more option
+	};
+	enum TexturePixelDataType
+	{
+		TEXTURE_PIXEL_DATA_UNSIGNED_BYTE = GL_UNSIGNED_BYTE,
+		TEXTURE_PIXEL_DATA_BYTE = GL_BYTE,
+		TEXTURE_PIXEL_DATA_UNSIGNED_SHORT = GL_UNSIGNED_SHORT,
+		TEXTURE_PIXEL_DATA_SHORT = GL_SHORT,
+		TEXTURE_PIXEL_DATA_UNSIGNED_INT = GL_UNSIGNED_INT,
+		TEXTURE_PIXEL_DATA_INT = GL_INT,
+		TEXTURE_PIXEL_DATA_HALF_FLOAT=GL_HALF_FLOAT,
+		TEXTURE_PIXEL_DATA_FLOAT=GL_FLOAT
+	};
+	
+	struct TextureSize
+	{
+		int width;
+		int height;
+	};
+	struct TextureData
+	{
+		TextureSize TextureSize;
+		TextureFormat m_textureFormat;
+		TextureInternalFormat m_textureInternalFormat;
+	};
+#pragma endregion
+
+	struct TexturePixelDataWrapper
+	{
+	public:
+		TexturePixelDataWrapper(const char* path, TextureSize* pTextureSize,int* pPresentChannelsCount);
+		~TexturePixelDataWrapper();
+		unsigned char* GetTexturePixelData()const { return m_pixelData; }
+	private:
+		unsigned char* m_pixelData;
+	};
+
+	class Texture
+	{
+	public:
+		Texture(const unsigned char* data, TextureInternalFormat textureInternalFormat, TextureFormat textureFormat,
+			TextureSize textureSize, TexturePixelDataType dataType, TextureWrap textureWrapS, TextureWrap textureWrapT);
+		~Texture();
+		void BindTexture()const;
+		GLuint GetTextureHandle()const { return m_textureHandle; }
+		void ResizeTexture(TextureSize newSize);
+		//Not tested;
+		std::shared_ptr<unsigned char[]> GetPixelData();
+	private:
+		void SetTextureProperties(const unsigned char* data);
+	private:
+		TextureSize m_textureSize;
+		TextureWrap m_textureWrapS;
+		TextureWrap m_textureWrapT;
+		TextureFormat m_textureFormat;
+		TextureInternalFormat m_textureInternalFormat;
+		TexturePixelDataType m_texturePixelDataType;
+		GLuint m_bindingPoint;
+		GLuint m_textureHandle;
+	};
+	//(NOTE)Consider factory method maybe.Since if we add more texture types as cubeMap and so on altho this also might not the best idea since nothing really changes 
+	//beside a filed and maybe 2 conditions not sure if its worth the code complication?
+	class TextureBuilder
+	{
+	public:
+		TextureBuilder& SetTextureFormat(TextureFormat format) { this->textureFormat = format; return *this; }
+		TextureBuilder& SetTextureInternalFormat(TextureInternalFormat internalFormat) { this->textureInternalFormat = internalFormat; return *this; }
+		TextureBuilder& SetTextureWrapS(TextureWrap textureWrap) { this->textureWrapT = textureWrap; return *this; }
+		TextureBuilder& SetTextureWrapT(TextureWrap textureWrap) { this->textureWrapT = textureWrap; return *this; }
+		TextureBuilder& SetTextureSize(TextureSize size) { this->textureSize = size; return *this; }
+		TextureBuilder& SetTexturePixelData(const unsigned char* data) { this->data = data; return *this; }
+		TextureBuilder& SetTexturePixelDataType(TexturePixelDataType dataType) { this->texturePixelDataType = dataType; return *this; }
+		std::shared_ptr<Texture> buildTexture()const{ return std::make_shared<Texture>(data, textureInternalFormat, textureFormat, textureSize, texturePixelDataType, textureWrapS, textureWrapT); }
+	private:
+		TextureWrap textureWrapS = TextureWrap::TEXTURE_WRAP_REPEAT;
+		TextureWrap textureWrapT = TextureWrap::TEXTURE_WRAP_REPEAT;
+		TextureSize textureSize = {500,500};
+		TextureFormat textureFormat;
+		TextureInternalFormat textureInternalFormat;
+		TexturePixelDataType texturePixelDataType = TexturePixelDataType::TEXTURE_PIXEL_DATA_UNSIGNED_BYTE;
+		const unsigned char* data = nullptr;
+	};
+}
+


### PR DESCRIPTION
Added the Texture class wich can be used to create a GPU texture and provides some methtot to acces it.It uses the build pattern to build the actuall texture with the TextureBuild object.WIth this pattern the texture can have more options for data, pixel data type, format and so on.Added also a wrapper class for reading texture data using stbi_image librabry the class is created and as long that is not out of scope it mantains the lifetime of the pixel array and at the end of the life cycle it destroies it.This is moslty done since stbi have its own free method altho smart point provide a custom de-allocator but if its bad i will change it in the future.  