### PR TITLE
Skybox rendering fixes.

### DIFF
--- a/Shaders/SkyboxShader.glsl
+++ b/Shaders/SkyboxShader.glsl
@@ -10,11 +10,14 @@ layout(std140) uniform Matrices
 	mat4 ModelMatrix;
 	mat4 NormalMatrix;
 };
+uniform bool uIsProjectionPerspective;
 void main()
 {
 	mat4 skyboxView = mat4(mat3(ViewMatrix));
-	vec4 pos = ProjectionMatrix*skyboxView*vec4(position,1);
-	gl_Position = pos.xyww;
+	mat4 finalProjection = uIsProjectionPerspective ? ProjectionMatrix : mat4(1);
+
+	vec4 pos = finalProjection*skyboxView*vec4(position,1);
+	gl_Position =uIsProjectionPerspective ? pos.xyww : pos.xyzz;
 	FragCoords = position;
 }
 #Shader:fragment
@@ -25,5 +28,5 @@ in vec3 FragCoords;
 uniform samplerCube skyboxSampler;
 void main()
 {
-	FragColor = texture(skyboxSampler,FragCoords);
+	FragColor = vec4(texture(skyboxSampler,FragCoords).rgb,1);
 }

--- a/src/3D_Object_Viewer.cpp
+++ b/src/3D_Object_Viewer.cpp
@@ -58,8 +58,8 @@ int main()
 	}
 
 	glewExperimental = GL_TRUE;
+    stbi_set_flip_vertically_on_load(true);
 
-	stbi_set_flip_vertically_on_load(true);
 	stbi_flip_vertically_on_write(true);
 
 

--- a/src/Helpers/TextureHelpers.cpp
+++ b/src/Helpers/TextureHelpers.cpp
@@ -23,7 +23,7 @@ constexpr OBJ_Viewer::TextureFormat_ OBJ_Viewer::TextureFormatEnumConverter::Get
 	}
 }
 
-constexpr uint8_t OBJ_Viewer::TextureFormatEnumConverter::GetChannelCountByFormat(TextureFormat_ format)
+constexpr size_t OBJ_Viewer::TextureFormatEnumConverter::GetChannelCountByFormat(TextureFormat_ format)
 {
 	switch (format)
 	{
@@ -115,8 +115,8 @@ int OBJ_Viewer::TexturePixelSaver::SaveBitmap(const char* filePath_name, Size2D 
 OBJ_Viewer::TexturePixelReader::TexturePixelReader(const char* path)
 {
 	int channelCount;
-
 	m_pixelData = stbi_load(path, &m_textureSize.width, &m_textureSize.height, &channelCount, 0);
+    
 	if (!m_pixelData)
 	{
 		LOGGER_LOG_ERROR("STBI_IMAGE failed to read or allocate texture at path:'{0}'", path);

--- a/src/Helpers/TextureHelpers.h
+++ b/src/Helpers/TextureHelpers.h
@@ -31,7 +31,7 @@ namespace OBJ_Viewer {
 	struct TextureFormatEnumConverter
 	{
 		static constexpr TextureFormat_ GetFormatByChannelCount(int channelCount);
-		static constexpr uint8_t GetChannelCountByFormat(TextureFormat_ format);
+		static constexpr size_t GetChannelCountByFormat(TextureFormat_ format);
 	};
 	struct TextureFileEnumConverter
 	{
@@ -57,10 +57,11 @@ namespace OBJ_Viewer {
 		TexturePixelReader(const char* path);
 		~TexturePixelReader(){ stbi_image_free(m_pixelData); }
 		unsigned char* GetTexturePixelData()const { return m_pixelData; }
+        size_t GetTextureByteSize()const { return static_cast<size_t>(m_textureSize.width) * static_cast<size_t>(m_textureSize.height) * TextureFormatEnumConverter::GetChannelCountByFormat(m_textureFormat); }
 		Size2D GetTextureSize()const { return m_textureSize; }
 		TextureFormat_ GetTextureFormat()const { return m_textureFormat; }
 		bool isTextureValid()const { return m_pixelData != nullptr; }
-		uint8_t GetChannelCount()const { return TextureFormatEnumConverter::GetFormatByChannelCount(m_textureFormat); }
+		uint8_t GetChannelCount()const { return TextureFormatEnumConverter::GetChannelCountByFormat(m_textureFormat); }
 	private:
 		unsigned char* m_pixelData = nullptr;
 		Size2D m_textureSize {};

--- a/src/Rendering/Renderer.cpp
+++ b/src/Rendering/Renderer.cpp
@@ -96,6 +96,7 @@ void OBJ_Viewer::Renderer::RenderSkybox(const ShaderClass& skyboxShader, const S
 	glActiveTexture(GL_TEXTURE0);
 	skybox.BindSkyboxTexture();
 	skyboxShader.SetUniformSet1Int("skyboxSampler", 0);
+    skyboxShader.SetUniformSet1Int("uIsProjectionPerspective", mainCamera.IsCameraProjectionPerspective());
 	skybox.GetSkyboxVAO().BindBuffer();
 	glDrawElements(GL_TRIANGLES, skybox.GetSkyboxVAO().GetIndexCount(), GL_UNSIGNED_INT, NULL);
 	skybox.GetSkyboxVAO().UnBind();

--- a/src/Rendering/SceneRenderer.h
+++ b/src/Rendering/SceneRenderer.h
@@ -21,7 +21,7 @@ namespace OBJ_Viewer {
 		/// <param name="renderSettings">The instruction on how to render the scene. </param>
 		/// <param name="outputFrameBuffer">The output framebuffer if none provided is understood to be the default provided by GLFW.</param>
 		void RenderScene(const APP_SETTINGS::RenderStateSettings& renderSettings,Framebuffer* outputFrameBuffer = nullptr);
-		void SwapSkyboxFaces(SkyboxFace toSwap, SkyboxFace with);
+		void SwapSkyboxFaces(SkyboxFace_ toSwap, SkyboxFace_ with);
 		std::weak_ptr<Model> GetSceneModel() { return m_sceneModel; }
 		std::weak_ptr<Skybox> GetSkyboxModel() { return m_sceneSkybox; }
 	private:

--- a/src/Scene/Camera.cpp
+++ b/src/Scene/Camera.cpp
@@ -4,7 +4,7 @@
 #include "Controls/AppKeyBindings.h"
 
 #define OBJ_VIEWER_IS_Y_VECTOR_FLIPPED(X) std::cos(glm::radians(X)) < 0
-#define ASPECT(X,Y) (float)X / (float)Y
+#define OBJ_VIEWER_SCREEN_ASPECT(X,Y) (float)X / (float)Y
 
 constexpr float kZfar = 100.0f;
 constexpr float kZnear = 0.1f;
@@ -15,7 +15,7 @@ OBJ_Viewer::Camera::Camera(float CameraZoom, Size2D screenSize, Application& app
 	m_app(app),m_cameraCenter(kCameraDefaultOrigin)
 {
 	this->m_zoom = CameraZoom;
-	m_projectionMatrix = glm::perspective(glm::radians(kFieldOfView), ASPECT(screenSize.width, screenSize.height), kZnear, kZfar);
+	m_projectionMatrix = glm::perspective(glm::radians(kFieldOfView), OBJ_VIEWER_SCREEN_ASPECT(screenSize.width, screenSize.height), kZnear, kZfar);
 
 	this->m_EulerAngles.m_pitchAngle = 0.0f;
 	this->m_EulerAngles.m_yawAngle = 90.0f;
@@ -106,8 +106,8 @@ void OBJ_Viewer::Camera::onMousePositionChanged(MousePositionEvent& e)
 
 void OBJ_Viewer::Camera::onViewportChanged(SceneViewportResizeEvent& e)
 {
-	const Size2D window_size = e.GetViewportSize();
-	RecalculateProjection(window_size);
+	const Size2D viewport_size = e.GetViewportSize();
+	RecalculateProjection(viewport_size);
 }
 
 void OBJ_Viewer::Camera::onKeyPressedEvent(KeyboardKeyEvent& e)
@@ -119,14 +119,14 @@ void OBJ_Viewer::Camera::onKeyPressedEvent(KeyboardKeyEvent& e)
 	}
 }
 
-void OBJ_Viewer::Camera::RecalculateProjection(Size2D windowSize)
+void OBJ_Viewer::Camera::RecalculateProjection(Size2D viewport_size)
 {
-	windowSize = (windowSize.width == 0 || windowSize.height == 0) ? m_app.GetSceneViewport().GetViewportSize() : windowSize;
+    viewport_size = (viewport_size.width == 0 || viewport_size.height == 0) ? m_app.GetSceneViewport().GetViewportSize() : viewport_size;
 
 	if (m_isProjectionPerspective)
-		m_projectionMatrix = glm::perspective(glm::radians(kFieldOfView), ASPECT(windowSize.width, windowSize.height) , kZnear, kZfar);
+		m_projectionMatrix = glm::perspective(glm::radians(kFieldOfView), OBJ_VIEWER_SCREEN_ASPECT(viewport_size.width, viewport_size.height) , kZnear, kZfar);
 	else
-		CalculateOthoProjection(windowSize);
+		CalculateOthoProjection(viewport_size);
 }
 
 void OBJ_Viewer::Camera::OnProjectionModeChanged(EventCameraProjectionChanged& e)
@@ -135,7 +135,7 @@ void OBJ_Viewer::Camera::OnProjectionModeChanged(EventCameraProjectionChanged& e
 	RecalculateProjection();
 }
 
-void OBJ_Viewer::Camera::CalculateOthoProjection(Size2D windowSize)
+void OBJ_Viewer::Camera::CalculateOthoProjection(Size2D viewport_size)
 {
 	constexpr float kOrthographicScaleFactor = 500.0f;
 
@@ -144,8 +144,8 @@ void OBJ_Viewer::Camera::CalculateOthoProjection(Size2D windowSize)
 	* box defined by the left,right,bottom,top planes so that smaller values will get bigger meaning that since ortho matrix
 	* is just a scale and translate we make the scale bigger by multiplying left,right,bottom,top with the 'orthoScale'.
 	*/
-	m_projectionMatrix = glm::ortho(-((float)windowSize.width / 2) * orthographic_scale, ((float)windowSize.width / 2) * orthographic_scale,
-		-((float)windowSize.height / 2) * orthographic_scale, ((float)windowSize.height / 2) * orthographic_scale, -1.f/ orthographic_scale, kZfar);
+	m_projectionMatrix = glm::ortho(-((float)viewport_size.width / 2) * orthographic_scale, ((float)viewport_size.width / 2) * orthographic_scale,
+		-((float)viewport_size.height / 2) * orthographic_scale, ((float)viewport_size.height / 2) * orthographic_scale, -1.f/ orthographic_scale, kZfar);
 }
 
 

--- a/src/Scene/Camera.h
+++ b/src/Scene/Camera.h
@@ -37,6 +37,7 @@ namespace OBJ_Viewer
 		glm::mat4 GetViewProjMatrix()const { return m_projectionMatrix * m_viewMatrix; }
 		glm::mat4 GetViewProjNoTranslation()const { return m_projectionMatrix* glm::mat4(glm::mat3(m_viewMatrix)); };
 		glm::vec3 GetCameraPos()const { return this->m_position; }
+        bool IsCameraProjectionPerspective()const { return m_isProjectionPerspective; }
 		void SetProjection(bool isProjectionPerspective = true) { m_isProjectionPerspective = isProjectionPerspective; RecalculateProjection(); }
 	private:
 		void RecalculateViewMatrix();

--- a/src/Scene/Skybox.h
+++ b/src/Scene/Skybox.h
@@ -5,16 +5,15 @@
 #include "gpu_side/OpenGLBuffer.h"
 #include "Helpers/TextureHelpers.h"
 namespace OBJ_Viewer
-{
-	
-	enum SkyboxFace
+{	
+	enum SkyboxFace_
 	{
-		SKYBOX_FACE_RIGHT = 0,
-		SKYBOX_FACE_LEFT = 1,
-		SKYBOX_FACE_TOP = 2,
-		SKYBOX_FACE_BOTTOM = 3,
-		SKYBOX_FACE_FRONT = 4,
-		SKYBOX_FACE_BACK = 5
+		SkyboxFace_kRight  =  0,
+		SkyboxFace_kLeft   =  1,
+        SkyboxFace_kTop    =  2,
+        SkyboxFace_kBottom =  3,
+        SkyboxFace_kFront  =  4,
+        SkyboxFace_kBack   =  5
 	};
 	class Skybox {
 	public:
@@ -22,13 +21,12 @@ namespace OBJ_Viewer
 		Skybox(const std::array<TexturePixelReader,Skybox::SKYBOX_FACE_COUNT>& textures);
 		~Skybox();
 		void BindSkyboxTexture()const { glBindTexture(GL_TEXTURE_CUBE_MAP, m_cubeMapHandle); }
-		void SwapSkyboxFaceTextures(SkyboxFace toBeSwapped, SkyboxFace swappedWith);
+		void SwapSkyboxFaceTextures(SkyboxFace_ toBeSwapped, SkyboxFace_ swappedWith);
 		const VertexAttributeObject& GetSkyboxVAO()const { return *m_skyboxVAO; }
-		const std::vector<std::shared_ptr<Texture>>& const GetSkyboxFaceTextures() { return m_faceTextures; }	
-		//TODO:Hide away the pointers make the unique and return the reference to them if needed
-	private:
-		std::vector<std::shared_ptr<Texture>> m_faceTextures;
-		std::vector<OpenGLBuffer> m_PixelBuffers;
+		const std::array<std::shared_ptr<Texture>, SKYBOX_FACE_COUNT>& const GetSkyboxFaceTextures() { return m_faceTextures; }
+    private:
+		std::array<std::shared_ptr<Texture>, SKYBOX_FACE_COUNT> m_faceTextures;
+		std::array<std::unique_ptr<OpenGLBuffer>, SKYBOX_FACE_COUNT> m_PixelBuffers;
 		GLuint m_cubeMapHandle = 0;
 		std::unique_ptr<VertexAttributeObject> m_skyboxVAO;
 		Size2D m_CubeMapTextSize;

--- a/src/UI/UILayer.cpp
+++ b/src/UI/UILayer.cpp
@@ -1,9 +1,9 @@
 #include "pch.h"
-#include "UILayer.h"
-#include "Helpers/DialogWrapper.h"
-#include "Profiling/AppProfiler.h"
 #include "Enums/FIleImageEnums.h"
+#include "Helpers/DialogWrapper.h"
 #include "Helpers/TextureHelpers.h"
+#include "Profiling/AppProfiler.h"
+#include "UILayer.h"
 
 enum ImageResolutionEnum_
 {
@@ -16,14 +16,14 @@ enum ImageResolutionEnum_
 constexpr ImGuiWindowFlags_ APP_WINDOW_STYLE_FLAGS = ImGuiWindowFlags_NoMove;
 
 #pragma region KEY_UI_LABEL_MAPS
-inline const std::unordered_map<OBJ_Viewer::SkyboxFace, const char*> kUI_SkyboxFaceLabelMap =
+inline const std::unordered_map<OBJ_Viewer::SkyboxFace_, const char*> kUI_SkyboxFaceLabelMap =
 {
-	{OBJ_Viewer::SKYBOX_FACE_RIGHT, "Right face"},
-	{OBJ_Viewer::SKYBOX_FACE_LEFT ,"Left face"},
-	{OBJ_Viewer::SKYBOX_FACE_TOP,"Top face"},
-	{OBJ_Viewer::SKYBOX_FACE_BOTTOM,"Bottom face"},
-	{OBJ_Viewer::SKYBOX_FACE_FRONT,"Front face"},
-	{OBJ_Viewer::SKYBOX_FACE_BACK,"Back face"}
+	{OBJ_Viewer::SkyboxFace_kRight, "Right face"},
+	{OBJ_Viewer::SkyboxFace_kLeft ,"Left face"},
+	{OBJ_Viewer::SkyboxFace_kTop,"Top face"},
+	{OBJ_Viewer::SkyboxFace_kBottom,"Bottom face"},
+	{OBJ_Viewer::SkyboxFace_kFront,"Front face"},
+	{OBJ_Viewer::SkyboxFace_kBack,"Back face"}
 };
 
 inline const std::unordered_map<ImageResolutionEnum_, const char *> kUI_ResolutionOptionLabelMap =
@@ -614,21 +614,21 @@ void OBJ_Viewer::UILayer::RenderSkyboxSettings()
 	}
 	if (auto sceneSkybox = m_mediator->GetSkybox().lock())
 	{
-		std::vector <std::shared_ptr<Texture>> skyboxTextures = sceneSkybox->GetSkyboxFaceTextures();
+		std::array<std::shared_ptr<Texture>,Skybox::SKYBOX_FACE_COUNT> skyboxTextures = sceneSkybox->GetSkyboxFaceTextures();
 
 		int noTextureLoaded = 0;
-		static SkyboxFace comboResult{};
+		static SkyboxFace_ comboResult{};
 		static std::string index_to_string = "## ";
 		for (uint8_t i = 0; i < Skybox::SKYBOX_FACE_COUNT; i++)
 		{
 			ImGui::Image((ImTextureID)skyboxTextures[i]->GetTextureHandle(),{ 50,50 }, ImVec2(0.0f, 1.0f), ImVec2(1.0f, 0.0f));
 			ImGui::SameLine();
 			index_to_string[index_to_string.size() - 1] = '0' + i;
-			comboResult = RenderComboBox<SkyboxFace>(index_to_string, kUI_SkyboxFaceLabelMap,
-				static_cast<SkyboxFace>(i));
+			comboResult = RenderComboBox<SkyboxFace_>(index_to_string, kUI_SkyboxFaceLabelMap,
+				static_cast<SkyboxFace_>(i));
 
 			if(i != comboResult)
-				m_mediator->GetSkybox().lock()->SwapSkyboxFaceTextures(static_cast<SkyboxFace>(i), comboResult);
+				m_mediator->GetSkybox().lock()->SwapSkyboxFaceTextures(static_cast<SkyboxFace_>(i), comboResult);
 		}
 
 		//TODO:Add texture preview;

--- a/src/gpu_side/Framebuffer.cpp
+++ b/src/gpu_side/Framebuffer.cpp
@@ -75,12 +75,12 @@ void OBJ_Viewer::Framebuffer::ResizeFramebuffer(Size2D newSize)
 
 }
 
-void OBJ_Viewer::Framebuffer::CopyFramebufferContent(const Framebuffer& framebufferToCopy)
+void OBJ_Viewer::Framebuffer::CopyFramebufferContent(const Framebuffer& framebufferToCopy, FramebufferBitMaskFlags_ mask)
 {
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, framebufferToCopy.m_framebuffer);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_framebuffer);
 	glBlitFramebuffer(0, 0, m_framebufferSize.width, m_framebufferSize.height, 0, 0,
-		m_framebufferSize.width, m_framebufferSize.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		m_framebufferSize.width, m_framebufferSize.height, mask, GL_NEAREST);
 }
 
 std::vector<OBJ_Viewer::Framebuffer::pixel_component> OBJ_Viewer::Framebuffer::GetFramebufferPixels(TextureFormat_ retrieveFormat)const

--- a/src/gpu_side/Framebuffer.h
+++ b/src/gpu_side/Framebuffer.h
@@ -12,6 +12,12 @@ namespace OBJ_Viewer {
 		//FRAMEBUFFER_NORMAL_ATTACHMENT = 4,
 		//FRAMEBUFFER_SPECULAR_ATTACHMENT = 8
 	};
+    enum FramebufferBitMaskFlags_
+    {
+        FramebufferBitMaskFlags_kColorBufferBit = GL_COLOR_BUFFER_BIT,
+        FramebufferBitMaskFlags_kDepthBufferBit = GL_DEPTH_BUFFER_BIT
+    };
+
 	class Framebuffer
 	{
 	public:
@@ -26,7 +32,7 @@ namespace OBJ_Viewer {
 		bool isFramebufferValid()const;
 		Size2D GetFramebufferSize()const { return m_framebufferSize; }
 		void ResizeFramebuffer(Size2D newSize);
-		void CopyFramebufferContent(const Framebuffer& framebufferToCopy);
+		void CopyFramebufferContent(const Framebuffer& framebufferToCopy, FramebufferBitMaskFlags_ mask = FramebufferBitMaskFlags_kColorBufferBit);
 		std::vector<pixel_component> GetFramebufferPixels(TextureFormat_ retrieveFormat)const;
 		~Framebuffer();
 	private:

--- a/src/gpu_side/OpenGLBuffer.cpp
+++ b/src/gpu_side/OpenGLBuffer.cpp
@@ -10,6 +10,7 @@ OBJ_Viewer::OpenGLBuffer::OpenGLBuffer(const BufferData& data):
 	glBindBuffer(data.type, 0);
 }
 
+
 OBJ_Viewer::OpenGLBuffer::~OpenGLBuffer()
 {
 	glDeleteBuffers(1, &this->m_bufferHandle);

--- a/src/gpu_side/OpenGLBuffer.h
+++ b/src/gpu_side/OpenGLBuffer.h
@@ -37,6 +37,7 @@ namespace OBJ_Viewer {
 	{
 	public:
 		OpenGLBuffer(const BufferData& data);
+        OpenGLBuffer(const OpenGLBuffer& other) = delete; //Recomend for chatching bugs if you dont intent to make copies.
 		void BindBuffer()const{ glBindBuffer(m_data.type, this->m_bufferHandle); }
 		void UnbindBuffer()const { glBindBuffer(m_data.type,0); }
 		~OpenGLBuffer();

--- a/src/gpu_side/VertexAttributeObject.cpp
+++ b/src/gpu_side/VertexAttributeObject.cpp
@@ -30,8 +30,8 @@ OBJ_Viewer::VertexAttributeObject::VertexAttributeObject(const std::vector<Verte
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
-	m_vertexData.indexCount = kVertexDataVectorRef.size();
-	m_vertexData.vertexCount = kIndexDataVectorRef.size();
+	m_vertexData.indexCount = kIndexDataVectorRef.size();
+	m_vertexData.vertexCount = kVertexDataVectorRef.size();
 }
 
 OBJ_Viewer::VertexAttributeObject::VertexAttributeObject(const std::vector<glm::vec3>& kPostionDataVectorRef,


### PR DESCRIPTION
## Fixes
- Fixed problem when using AA the final image will tear when using skybox.
- Fixed the grid unprojecting bug where instead of near unprojection beeing -1 was 0.
- Fixed the problem when itter_swapping cuasing the program to copy the Pixel buffer and lose the texture.
- Added FramebufferBitMaskFlags_ enum for selecting which framebuffer texture you want to copy.
- Fixed the issue when using orthographic projection the skybox will appear tiny.