### PR TITLE
Fixed camera bugs and more.

### DIFF
--- a/src/Rendering/RenderingCoordinator.cpp
+++ b/src/Rendering/RenderingCoordinator.cpp
@@ -75,7 +75,6 @@ void OBJ_Viewer::RenderingCoordinator::onEventTakeScreenshot(const ScreenshotEve
         m_renderingConfigSettings.m_isWireGridOn && !kEventDataImageData.renderObjectOnly;
 
 	m_application.SubmitSceneViewportSize(OutputImageViewport);
-    m_UILayer->GetInputFramebuffer().ResizeFramebuffer({ OutputImageViewport.width, OutputImageViewport.height });
 
 	m_sceneRenderer->RenderScene(m_renderingConfigSettings, &m_UILayer->GetInputFramebuffer());
 
@@ -90,8 +89,6 @@ void OBJ_Viewer::RenderingCoordinator::onEventTakeScreenshot(const ScreenshotEve
   
 	//Restore original state
 	m_application.SubmitSceneViewportSize(kPreviousApplicationViewport);
-    //Change this so that the UI framebuffer listen for resize events
-    m_UILayer->GetInputFramebuffer().ResizeFramebuffer({ kPreviousApplicationViewport.width, kPreviousApplicationViewport.height });
 
     m_renderingConfigSettings.m_isSkyboxOn = kPreviousSkyboxEnableState;
     m_renderingConfigSettings.m_isWireGridOn = kPreviousGridEnableState;
@@ -113,5 +110,6 @@ OBJ_Viewer::RenderingCoordinator::RenderingCoordinator(Application& application)
 	m_sceneRenderer = std::make_shared<SceneManager>(application);
 	m_application.AddEventListener(m_sceneRenderer);
 	m_UILayer = std::make_unique<UILayer>(m_application);
+    m_application.AddEventListener(m_UILayer);
 
 }

--- a/src/Rendering/RenderingCoordinator.h
+++ b/src/Rendering/RenderingCoordinator.h
@@ -15,7 +15,7 @@ namespace OBJ_Viewer
 		void OnEvent(Event& e) override;
 	private:
 		Application& m_application;
-		std::unique_ptr<UILayer> m_UILayer;
+		std::shared_ptr<UILayer> m_UILayer;
 		std::shared_ptr<SceneManager> m_sceneRenderer;
 		WindowState_ m_currentWindowState;
 		std::future<int> m_saveImgResult;

--- a/src/Rendering/SceneRenderer.cpp
+++ b/src/Rendering/SceneRenderer.cpp
@@ -252,8 +252,6 @@ void OBJ_Viewer::SceneManager::OnEvent(Event& e)
 	else if (e.GetEventCategory() == EventCategory_kAppEvent && e.GetEventType() == EventType_kViewportSizeChanged)
 	{
 		auto& sceneViewportEvent = dynamic_cast<SceneViewportResizeEvent&>(e);
-		const Viewport& newViewport = sceneViewportEvent.GetViewport();
-		glViewport(newViewport.x, newViewport.y, newViewport.width, newViewport.height);
 
 		m_multiSampleSceneFrameBuffer.ResizeFramebuffer(sceneViewportEvent.GetViewportSize());
 		m_intermidiateFramebuffer.ResizeFramebuffer(sceneViewportEvent.GetViewportSize());

--- a/src/Scene/Camera.h
+++ b/src/Scene/Camera.h
@@ -7,26 +7,35 @@
 namespace OBJ_Viewer
 {
 	struct EulerAngles {
-		float m_yawAngle;
-		float m_pitchAngle;
+		float yawAngle;
+		float pitchAngle;
 		EulerAngles& operator+=(const EulerAngles& other) {
-			this->m_yawAngle += other.m_yawAngle;
-			this->m_pitchAngle += other.m_pitchAngle;
+			this->yawAngle += other.yawAngle;
+			this->pitchAngle += other.pitchAngle;
 			return *this;
 		}
 		EulerAngles& operator-(const EulerAngles& other)
 		{
-			this->m_yawAngle -= other.m_yawAngle;
-			this->m_pitchAngle -= other.m_pitchAngle;
+			this->yawAngle -= other.yawAngle;
+			this->pitchAngle -= other.pitchAngle;
 			return *this;
 		}
 	};
 	class EulerAngleHelper {
 	public:
-		EulerAngles calculateEulerAngles(Position2D newMousePosition);
-		void ConstrainAngles(EulerAngles& angle);
+        EulerAngleHelper()
+        {
+            m_EulerAngles.pitchAngle = 0.0f;
+            m_EulerAngles.yawAngle = 90.0f;
+        }
+        EulerAngles GetEulerAngles()const { return m_EulerAngles; }
+        static EulerAngles ConvertMousePositionToAngles(Position2D position_to_convert);
+        void IncreaseEulerAngles(const EulerAngles& angles) { m_EulerAngles += angles; ConstrainAngles(); }
+    private:
+        bool IsAngleWithinBounds(float angle) { return angle >= -360.0f && angle <= 360.0f; }
+		void ConstrainAngles();
 	private:
-		Position2D m_previousMousePosition;
+        EulerAngles m_EulerAngles {};
 	};
 
 	class Camera : public Listener
@@ -40,6 +49,8 @@ namespace OBJ_Viewer
         bool IsCameraProjectionPerspective()const { return m_isProjectionPerspective; }
 		void SetProjection(bool isProjectionPerspective = true) { m_isProjectionPerspective = isProjectionPerspective; RecalculateProjection(); }
 	private:
+        bool IsCameraYVectorFlipped(float pitch_angle);
+        float GetAspectRatio(Size2D size) {return static_cast<float>(size.width) / static_cast<float>(size.height); }
 		void RecalculateViewMatrix();
 		void CalculatePositionVector();
 #pragma region On Event
@@ -55,15 +66,13 @@ namespace OBJ_Viewer
 		float m_zoom;
 		glm::mat4 m_projectionMatrix;
 		glm::mat4 m_viewMatrix;
-		EulerAngles m_EulerAngles;
 		EulerAngleHelper m_EulerAngleHelper;
 		glm::vec3 m_position;
 		InputHandler& m_applicationInputHandler;
         const SceneViewport& m_applicationViewportManager;
-
 		glm::vec3 m_cameraCenter;
-		Position2D m_lastMousePos = Position2D{0,0};
-
+		Position2D m_lastMouseMovementPosition{};
+        Position2D m_lastMouseShiftPosition{};
 		bool m_isProjectionPerspective = true;
 		// Inherited via Listener
 		void OnEvent(Event& e) override;

--- a/src/UI/UILayer.cpp
+++ b/src/UI/UILayer.cpp
@@ -42,6 +42,16 @@ void OBJ_Viewer::UILayer::isAppWindowFocused(APP_FOCUS_REGIONS::AppWindowID wind
 		windowID : m_currentlyFocusedWindow;
 }
 
+void OBJ_Viewer::UILayer::OnEvent(Event& e)
+{
+    if (e.GetEventCategory() == EventCategory_kAppEvent && e.GetEventType() == EventType_kViewportSizeChanged)
+    {
+        auto& sceneViewportEvent = dynamic_cast<SceneViewportResizeEvent&>(e);
+        m_UI_inputFramebuffer.ResizeFramebuffer(sceneViewportEvent.GetViewportSize());
+    }
+
+}
+
 void OBJ_Viewer::UILayer::RenderUI(APP_SETTINGS::SceneConfigurationSettings& scene_config_settings_ref,
     std::weak_ptr<Model> scene_model, std::weak_ptr<MaterialRegistry> material_registry,
     std::weak_ptr<Skybox> scene_skybox)

--- a/src/UI/UILayer.h
+++ b/src/UI/UILayer.h
@@ -5,7 +5,7 @@
 #include "Rendering/SceneConfigurationSettingsStruct.h"
 namespace OBJ_Viewer {
 
-	class UILayer
+	class UILayer : public Listener
 	{
 	public:
         UILayer(Application& appState);
@@ -27,7 +27,10 @@ namespace OBJ_Viewer {
 		Framebuffer m_UI_inputFramebuffer;
 		ImGuiWindowFlags m_imGuiWindowFlags;
 		ImGuiDockNodeFlags m_imgGuiDockSpaceFlags;
-	};
+
+        // Inherited via Listener
+        void OnEvent(Event& e) override;
+    };
 	template<typename T>
 	inline T UILayer::RenderComboBox(const std::string& comboLabel, const std::unordered_map<T, const char*>& items,
 		const T& previewItem)


### PR DESCRIPTION
## Things fixed
- Bug when camera rotation is exactly at +/- 90 or +/- 270 the due to precision error the cos function will return negative value instead of 0 causing the y vector to flip.
- Moved the angle logic into the Euler class helper.
- Made the UILayer a listener to events so that now on viewportUpdate the UIFramebuffer is resized instead of someone else needing to resize it.