### PR TITLE
Added checkboard for handling cases when a texture is not present and…

### DIFF
--- a/Shaders/SingleTextureInspectShader.glsl
+++ b/Shaders/SingleTextureInspectShader.glsl
@@ -23,17 +23,24 @@ void main()
 #Shader:fragment
 #version 330 core
 
+#define TEXTURE_NOT_PRESENT_COLOR  vec4(1.0, 0.0, 1.0, 1.0)
 #include "ColorSpaceUtilityFunctions.glsl"
 
 out vec4 FragColor;
 in vec2 Frag_UV_Coords;
 uniform sampler2D textureToInspect;
+uniform bool isTexturePresent;
 uniform bool uIsTextureInSRGB;
 
 void main()
 {
-	vec4 sampledTexel = texture(textureToInspect,Frag_UV_Coords);
-	FragColor = uIsTextureInSRGB ? vec4(toLinear(sampledTexel)) : sampledTexel;
+	vec4 sampledTexel;
+	if(isTexturePresent)
+		sampledTexel = texture(textureToInspect,Frag_UV_Coords);
+	else
+		sampledTexel = TEXTURE_NOT_PRESENT_COLOR;
+
+	FragColor = !isTexturePresent || uIsTextureInSRGB ? vec4(toLinear(sampledTexel)) : sampledTexel;
 }
 
 

--- a/src/Enums/TextureEnums.h
+++ b/src/Enums/TextureEnums.h
@@ -26,6 +26,13 @@ namespace OBJ_Viewer {
 		TextureFormat_kRGBA = GL_RGBA ///< Four-channel format, typically used for red, green, blue, and alpha, but can represent any four pixel components.
 	};
 
+    enum TextureMagMinFilters_
+    {
+        TextureMagMinFilters_kUnknown,              ///< For debugging
+        TextureMagMinFilters_kLinear = GL_LINEAR,    ///< Represents 'GL_LINEAR'.
+        TextureMagMinFilters_kNearest= GL_NEAREST,  ///< Represents 'GL_NEAREST'
+    };
+
     /**
       * @brief Enum representing internal formats for textures in GPU memory.
       *

--- a/src/Rendering/Renderer.h
+++ b/src/Rendering/Renderer.h
@@ -176,7 +176,7 @@ namespace OBJ_Viewer {
          */
 		void RenderSkybox(const ShaderClass& skyboxShader, const Skybox& skybox, bool is_camera_perspective);
 	private:
-		std::unique_ptr<Texture> CreateDummyTexture(const std::string& path);
+		std::unique_ptr<Texture> CreateDummyTexture(const unsigned char* textureData);
         /**
          * @brief Binds a material to the shader based on the provided MaterialRenderingFlags_. 
          * 

--- a/src/UI/UILayer.h
+++ b/src/UI/UILayer.h
@@ -153,7 +153,8 @@ namespace OBJ_Viewer {
 		Framebuffer m_UI_inputFramebuffer; ///< The scene input framebuffer(This might be moved in the coordinator and be passed as a parameter.) 
 		ImGuiWindowFlags m_imGuiWindowFlags;//< ImGUI window flags.
 		ImGuiDockNodeFlags m_imgGuiDockSpaceFlags;//< ImGUI docking flags.
-        bool m_isFirstFrame = true; ///< Is the currently rendering frame the first(This is reserved might be moved as a static variable.)
+        bool m_isFirstFrame = true; ///< Is the currently rendering frame the first(This is reserved might be moved as a static variable
+        std::unique_ptr<Texture> m_TextureNotPresent; ///< Texture used when another texture is not present.
         /**
          * @brief Currently used for the UI framebuffer resize. 
          */

--- a/src/gpu_side/Texture.cpp
+++ b/src/gpu_side/Texture.cpp
@@ -4,11 +4,14 @@
 
 OBJ_Viewer::Texture::Texture(const unsigned char* texture_pixel_data, TextureInternalFormat_ texture_internal_format,
 	TextureFormat_ texture_format,Size2D texture_size, GPUDataType_ texture_data_type, TextureWrap_ texture_wrapping_mode_on_S,
-	TextureWrap_ texture_wrapping_mode_on_T, bool is_texture_multi_sampled,uint8_t sample_count):
+	TextureWrap_ texture_wrapping_mode_on_T, TextureMagMinFilters_ magnification_filtering_mode,
+    TextureMagMinFilters_ minification_filtering_mode, bool is_texture_multi_sampled,uint8_t sample_count):
 
 	m_textureSize(texture_size),m_textureWrapS(texture_wrapping_mode_on_S), m_textureWrapT(texture_wrapping_mode_on_T),
 	m_textureFormat(texture_format), m_textureInternalFormat(texture_internal_format),
-	m_texturePixelDataType(texture_data_type),m_isMultiSample(is_texture_multi_sampled),m_sampleCount(sample_count)
+	m_texturePixelDataType(texture_data_type),
+    m_MagnificationFilter(magnification_filtering_mode), m_MinificationFilter(minification_filtering_mode),
+    m_isMultiSample(is_texture_multi_sampled),m_sampleCount(sample_count)
 {
     
 	m_target = is_texture_multi_sampled ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
@@ -35,8 +38,8 @@ void OBJ_Viewer::Texture::SetTextureProperties(const unsigned char* texture_pixe
 		glTexImage2D(m_target, 0, m_textureInternalFormat,
 			m_textureSize.width, m_textureSize.height, 0, m_textureFormat, m_texturePixelDataType, texture_pixel_data);
 
-		glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, m_MagnificationFilter);
+		glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, m_MinificationFilter);
 
 		glTexParameteri(m_target, GL_TEXTURE_WRAP_T, m_textureWrapS);
 		glTexParameteri(m_target, GL_TEXTURE_WRAP_S, m_textureWrapT);

--- a/src/gpu_side/Texture.h
+++ b/src/gpu_side/Texture.h
@@ -38,7 +38,8 @@ namespace OBJ_Viewer {
          */
 		Texture(const unsigned char* texture_pixel_data, TextureInternalFormat_ texture_internal_format,
 			TextureFormat_ texture_format, Size2D texture_size, GPUDataType_ texture_data_type, TextureWrap_ texture_wrapping_mode_on_S,
-			TextureWrap_ texture_wrapping_mode_on_T, bool is_texture_multi_sampled, uint8_t sample_count);
+			TextureWrap_ texture_wrapping_mode_on_T, TextureMagMinFilters_ magnification_filtering_mode,
+            TextureMagMinFilters_ minification_filtering_mode,bool is_texture_multi_sampled, uint8_t sample_count);
         /**
          * @brief Release the GPU-based texture resource. 
          */
@@ -105,6 +106,9 @@ namespace OBJ_Viewer {
 		bool m_isMultiSample;                                     ///< Flag indicating if the texture is a multi-sample texture (true if multi-sampled, false otherwise). 
 		uint8_t m_sampleCount;                                    ///< Number of samples per pixel in the texture. Used only if m_isMultiSample is true. 
 		GLuint m_textureHandle;                                   ///< OpenGL handle/ID representing the texture. Use this for texture related API calls.
+        TextureMagMinFilters_ m_MagnificationFilter;
+        TextureMagMinFilters_ m_MinificationFilter;
+
 	};
 
 
@@ -120,10 +124,11 @@ namespace OBJ_Viewer {
 		TextureBuilder& SetTexturePixelDataType(GPUDataType_ dataType) { this->texturePixelDataType = dataType; return *this; }
 		TextureBuilder& isTextureMultiSample(bool val) { isMultiSample = val;  return *this;}
 		TextureBuilder& SetSampleCount(uint8_t sampleCount) { texSampleCount = sampleCount;  return *this;}
-
+        TextureBuilder& SetMagFilter(TextureMagMinFilters_ filter) { magFilter = filter; return *this; }
+        TextureBuilder& SetMinFilter(TextureMagMinFilters_ filter) { minFilter = filter; return *this; }
 		std::unique_ptr<Texture> buildTexture()const
 		{ return std::make_unique<Texture>(data, textureInternalFormat, textureFormat, textureSize,
-			texturePixelDataType, textureWrapS, textureWrapT, isMultiSample, texSampleCount); }
+			texturePixelDataType, textureWrapS, textureWrapT, magFilter, minFilter, isMultiSample, texSampleCount); }
 	private:
 		TextureWrap_ textureWrapS = TextureWrap_::TextureWrap_kRepeat;
 		TextureWrap_ textureWrapT = TextureWrap_::TextureWrap_kRepeat;
@@ -131,6 +136,8 @@ namespace OBJ_Viewer {
 		TextureFormat_ textureFormat;
 		TextureInternalFormat_ textureInternalFormat;
 		GPUDataType_ texturePixelDataType = GPUDataType_::GPUDataType_kUnsignedByte;
+        TextureMagMinFilters_ magFilter = TextureMagMinFilters_kLinear;
+        TextureMagMinFilters_ minFilter = TextureMagMinFilters_kLinear;
 		const unsigned char* data = nullptr;
 		bool isMultiSample = false;
 		uint8_t texSampleCount = 4;


### PR DESCRIPTION
## Things added
- Visual indication when a texture is not present for UI and the mesh rendering.
- Added mag and min filter to the texture builder.
- Changed the renderer dummy textures to be embeded as const uchar data into the app.

## In details
- For the UI ImGui will use a checkboard patterned texture to show the image if it is not present instead of using pure black image.
- For the renderer I modified the SingleTextureShader so that if it detects that a texture is not existing it will render the mesh with color pink.The if statment is uniform based and not pixel based meaning we are not losing perfomance.